### PR TITLE
Ignore keys

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    decanter (0.8.1)
+    decanter (0.8.2)
       activesupport
 
 GEM
@@ -97,4 +97,4 @@ DEPENDENCIES
   rspec-rails
 
 BUNDLED WITH
-   1.10.6
+   1.14.4

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    decanter (0.8.2)
+    decanter (0.9.0)
       activesupport
 
 GEM

--- a/README.md
+++ b/README.md
@@ -422,6 +422,22 @@ No Need for Strong Params
 
 Since you are already defining your expected inputs in Decanter, you really don't need strong params anymore.
 
+Note: starting with version 0.7.2, the default strict mode is ```:with_exception```. You can modify your default strict mode in your configuration file (see the "Configuration" section below).
+
+#### Mode: with_exception (default mode)
+
+To raise exceptions when parameters arrive in your Decanter that you didn't expect:
+
+```ruby
+class TripDecanter <  Decanter::Base
+  strict :with_exception
+
+  input :name
+end
+```
+
+#### Mode: strict
+
 In order to tell Decanter to ignore the params not defined in your Decanter, just add the ```strict``` flag to your Decanters:
 
 ```ruby
@@ -432,17 +448,27 @@ class TripDecanter <  Decanter::Base
 end
 ```
 
-Or to raise exceptions when parameters arrive in your Decanter that you didn't expect:
+#### Requiring Params
+
+If you provide the option `:required` for an input in your decanter, an exception will be thrown if the parameters is nil or an empty string.
 
 ```ruby
 class TripDecanter <  Decanter::Base
-  strict :with_exception
-
-  input :name
+  input :name, :string, required: true
 end
 ```
 
-In addition, if you provide the option `:required` for an input in your decanter, an exception will be thrown if the parameters is nil or an empty string.
+#### Ignoring Params
+
+If you anticipate your decanter will receive certain params that you simply want to ignore and therefore do not want Decanter to raise an exception, you can do so by calling the `ignore` method:
+
+```ruby
+class TripDecanter <  Decanter::Base
+  ignore :created_at, :updated_at
+
+  input :name, :string
+end
+```
 
 Configuration
 ---

--- a/lib/decanter.rb
+++ b/lib/decanter.rb
@@ -5,14 +5,20 @@ module Decanter
   class << self
 
     def decanter_for(klass_or_sym)
-      case klass_or_sym
-      when Class
-        klass_or_sym.name
-      when Symbol
-        klass_or_sym.to_s.singularize.camelize
-      else
-        raise ArgumentError.new("cannot lookup decanter for #{klass_or_sym} with class #{klass_or_sym.class}")
-      end.concat('Decanter').constantize
+      decanter_name =
+        case klass_or_sym
+        when Class
+          klass_or_sym.name
+        when Symbol
+          klass_or_sym.to_s.singularize.camelize
+        else
+          raise ArgumentError.new("cannot lookup decanter for #{klass_or_sym} with class #{klass_or_sym.class}")
+        end.concat('Decanter')
+      begin
+        decanter_name.constantize
+      rescue
+        raise NameError.new("uninitialized constant #{decanter_name}")
+      end
     end
 
     def decanter_from(klass_or_string)
@@ -21,7 +27,11 @@ module Decanter
         when Class
           klass_or_string
         when String
-          klass_or_string.constantize
+          begin
+            klass_or_string.constantize
+          rescue
+            raise NameError.new("uninitialized constant #{klass_or_string}")
+          end
         else
           raise ArgumentError.new("cannot find decanter from #{klass_or_string} with class #{klass_or_string.class}")
         end

--- a/lib/decanter/core.rb
+++ b/lib/decanter/core.rb
@@ -44,6 +44,10 @@ module Decanter
         }
       end
 
+      def ignore(*args)
+        keys_to_ignore.push(*args)
+      end
+
       def strict(mode)
         raise( ArgumentError.new("#{self.name}: Unknown strict value #{mode}")) unless [:with_exception, true, false].include? mode
         @strict_mode = mode
@@ -61,16 +65,17 @@ module Decanter
       def unhandled_keys(args)
         unhandled_keys = args.keys.map(&:to_sym) -
           handlers.keys.flatten.uniq -
+          keys_to_ignore -
           handlers.values
             .select { |handler| handler[:type] != :input }
-            .map { |handler| "#{handler[:name]}_attributes".to_sym }
+            .map { |handler| "#{handler[:name]}_attributes".to_sym }            
 
         if unhandled_keys.any?
           case strict_mode
           when true
             p "#{self.name} ignoring unhandled keys: #{unhandled_keys.join(', ')}."
             {}
-          when :with_exception
+          when :with_exception            
             raise ArgumentError.new("#{self.name} received unhandled keys: #{unhandled_keys.join(', ')}.")
           else
             args.select { |key| unhandled_keys.include? key }
@@ -171,6 +176,10 @@ module Decanter
 
       def handlers
         @handlers ||= {}
+      end
+
+      def keys_to_ignore
+        @keys_to_ignore ||= []
       end
 
       def strict_mode

--- a/lib/decanter/version.rb
+++ b/lib/decanter/version.rb
@@ -1,3 +1,3 @@
 module Decanter
-  VERSION = '0.8.2'
+  VERSION = '0.9.0'
 end

--- a/spec/decanter/decanter_core_spec.rb
+++ b/spec/decanter/decanter_core_spec.rb
@@ -304,7 +304,7 @@ describe Decanter::Core do
         end
       end
 
-      context 'and strict mode is :with_exception', current: true do
+      context 'and strict mode is :with_exception' do
         before(:each) { dummy.strict :with_exception }
 
         context 'when there are no ignored keys' do

--- a/spec/decanter/decanter_core_spec.rb
+++ b/spec/decanter/decanter_core_spec.rb
@@ -304,11 +304,20 @@ describe Decanter::Core do
         end
       end
 
-      context 'and strict mode is :with_exception' do
+      context 'and strict mode is :with_exception', current: true do
+        before(:each) { dummy.strict :with_exception }
 
-        it 'raises an error' do
-          dummy.strict :with_exception
-          expect { dummy.unhandled_keys(args) }.to raise_error(ArgumentError)
+        context 'when there are no ignored keys' do
+          it 'raises an error' do
+            expect { dummy.unhandled_keys(args) }.to raise_error(ArgumentError)
+          end
+        end
+
+        context 'when the unhandled keys are ignored' do          
+          it 'does not raise an error' do
+            dummy.ignore :foo
+            expect { dummy.unhandled_keys(args) }.to_not raise_error(ArgumentError)
+          end          
         end
       end
 


### PR DESCRIPTION
This PR allows developers to define certain keys that they are aware will be coming through in the params but that they simply want to ignore (rather than throwing an exception).

For example:

```ruby
class TripDecanter <  Decanter::Base
  ignore :created_at, :updated_at

  input :name, :string
end
```

The example use case for this would be if the developer either does not have control over the frontend or does not have a way to scrub the data before it is submitted from the form. 