### PR TITLE
Updated Fixnum to Integer to solve Fixnum deprecation in Ruby 2.4.x

### DIFF
--- a/lib/decanter/parser/float_parser.rb
+++ b/lib/decanter/parser/float_parser.rb
@@ -3,7 +3,7 @@ module Decanter
     class FloatParser < ValueParser
       REGEX = /(\d|[.])/
 
-      allow Float, Fixnum
+      allow Float, Integer
 
       parser do |val, options|
         val.scan(REGEX).join.try(:to_f)

--- a/lib/decanter/parser/integer_parser.rb
+++ b/lib/decanter/parser/integer_parser.rb
@@ -3,7 +3,7 @@ module Decanter
     class IntegerParser < ValueParser
       REGEX = /(\d|[.])/
 
-      allow Fixnum
+      allow Integer
 
       parser do |val, options|
         val.is_a?(Float) ?

--- a/lib/decanter/parser/phone_parser.rb
+++ b/lib/decanter/parser/phone_parser.rb
@@ -3,7 +3,7 @@ module Decanter
     class PhoneParser < ValueParser
       REGEX = /\d/
 
-      allow Fixnum
+      allow Integer
 
       parser do |val, options|
         val.scan(REGEX).join.to_s


### PR DESCRIPTION
Starting with Ruby 2.4 Fixnum and Bignum have been deprecated. You can see more here: https://bugs.ruby-lang.org/issues/12005 Going forward Integer is used in place of both of these. Also of note, Integer is a super for both Fixnum and Bignum so this should work fine in versions prior to 2.4. I've only tested with 2.4.1, the latest stable version.

Let me know if I need to do anything else, setup a test, or if I did anything wrong. :)