### PR TITLE
Empty strings should return nil by default

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 /coverage
 .env
+.DS_Store

--- a/lib/decanter/parser/core.rb
+++ b/lib/decanter/parser/core.rb
@@ -11,7 +11,9 @@ module Decanter
         # Check if allowed, parse if not
         def parse(name, values, options={})
           case
-          when allowed?(values) || empty_values?(values)
+          when empty_values?(values)
+            { name => nil }
+          when allowed?(values)
             { name => values }
           else
             _parse(name, values, options)

--- a/lib/decanter/version.rb
+++ b/lib/decanter/version.rb
@@ -1,3 +1,3 @@
 module Decanter
-  VERSION = '0.9.2'
+  VERSION = '1.0.0'
 end

--- a/lib/decanter/version.rb
+++ b/lib/decanter/version.rb
@@ -1,3 +1,3 @@
 module Decanter
-  VERSION = '1.0.0'
+  VERSION = '1.0.0'.freeze
 end

--- a/spec/decanter/parser/parser_core_spec.rb
+++ b/spec/decanter/parser/parser_core_spec.rb
@@ -28,8 +28,8 @@ describe 'Core' do
     end
 
     context 'for empty string' do
-      it 'returns the value' do
-        expect(core.parse('first_name', '')).to match({'first_name' => ''})
+      it 'returns nil' do
+        expect(core.parse('first_name', '')).to match({'first_name' => nil})
       end
     end
 


### PR DESCRIPTION
When a value is empty (whether with `nil` or with an empty string, we should transform it to `nil`.

```ruby
params = { name: "" }
User.decant(params)
# currently returns: { name: "" }
# after this PR: { name: nil }
```

Use case: params often come in from a form with an empty string rather than a `nil` value. This means that the user didn't type anything into the form. Therefore, `nil` better represents the intent of the submission.