### PR TITLE
Singularize Class Name Bug

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -27,6 +27,7 @@ GEM
       thread_safe (~> 0.3, >= 0.3.4)
       tzinfo (~> 1.1)
     builder (3.2.3)
+    coderay (1.1.2)
     concurrent-ruby (1.0.5)
     crass (1.0.3)
     diff-lcs (1.3)
@@ -39,10 +40,15 @@ GEM
     loofah (2.1.1)
       crass (~> 1.0.2)
       nokogiri (>= 1.5.9)
+    method_source (0.8.2)
     mini_portile2 (2.3.0)
     minitest (5.10.3)
     nokogiri (1.8.1)
       mini_portile2 (~> 2.3.0)
+    pry (0.10.4)
+      coderay (~> 1.1.0)
+      method_source (~> 0.8.1)
+      slop (~> 3.4)
     rack (1.6.8)
     rack-test (0.6.3)
       rack (>= 1.0)
@@ -82,6 +88,7 @@ GEM
       json (>= 1.8, < 3)
       simplecov-html (~> 0.10.0)
     simplecov-html (0.10.2)
+    slop (3.6.0)
     thor (0.20.0)
     thread_safe (0.3.6)
     tzinfo (1.2.4)
@@ -94,6 +101,7 @@ DEPENDENCIES
   bundler (~> 1.9)
   decanter!
   dotenv
+  pry
   rake (~> 10.0)
   rspec-rails
   simplecov (~> 0.15.1)

--- a/decanter.gemspec
+++ b/decanter.gemspec
@@ -35,4 +35,5 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency 'rake', '~> 10.0'
   spec.add_development_dependency 'rspec-rails'
   spec.add_development_dependency 'dotenv'
+  spec.add_development_dependency 'pry'
 end

--- a/lib/decanter/parser.rb
+++ b/lib/decanter/parser.rb
@@ -1,6 +1,5 @@
 module Decanter
   module Parser
-
     class << self
       def parsers_for(klass_or_syms)
         Array.wrap(klass_or_syms)
@@ -16,7 +15,7 @@ module Decanter
         when Class
           klass_or_sym.name
         when Symbol
-          klass_or_sym.to_s.singularize.camelize
+          symbol_to_string(klass_or_sym)
         else
           raise ArgumentError.new("cannot lookup parser for #{klass_or_sym} with class #{klass_or_sym.class}")
         end.concat('Parser')
@@ -24,9 +23,36 @@ module Decanter
 
       # convert from a string to a constant
       def parser_constantize(parser_str)
+        # safe_constantize returns nil if match not found
         parser_str.safe_constantize ||
-        "Decanter::Parser::".concat(parser_str).safe_constantize ||
-        raise(NameError.new("cannot find parser #{parser_str}"))
+          concat_str(parser_str).safe_constantize ||
+          raise(NameError.new("cannot find parser #{parser_str}"))
+      end
+
+      # extract string transformation strategies
+      def symbol_to_string(klass_or_sym)
+        if singular_class_present?(klass_or_sym)
+          singularize_and_camelize_str(klass_or_sym)
+        else
+          camelize_str(klass_or_sym)
+        end
+      end
+
+      def singular_class_present?(klass_or_sym)
+        parser_str = singularize_and_camelize_str(klass_or_sym)
+        concat_str(parser_str).safe_constantize.present?
+      end
+
+      def singularize_and_camelize_str(klass_or_sym)
+        klass_or_sym.to_s.singularize.camelize
+      end
+
+      def camelize_str(klass_or_sym)
+        klass_or_sym.to_s.camelize
+      end
+
+      def concat_str(parser_str)
+        "Decanter::Parser::".concat(parser_str)
       end
 
       # expand to include preparsers

--- a/lib/decanter/parser.rb
+++ b/lib/decanter/parser.rb
@@ -1,6 +1,10 @@
+require_relative 'parser/utils'
+
 module Decanter
   module Parser
     class << self
+      include Utils
+
       def parsers_for(klass_or_syms)
         Array.wrap(klass_or_syms)
              .map { |klass_or_sym| klass_or_sym_to_str(klass_or_sym) }
@@ -27,32 +31,6 @@ module Decanter
         parser_str.safe_constantize ||
           concat_str(parser_str).safe_constantize ||
           raise(NameError.new("cannot find parser #{parser_str}"))
-      end
-
-      # extract string transformation strategies
-      def symbol_to_string(klass_or_sym)
-        if singular_class_present?(klass_or_sym)
-          singularize_and_camelize_str(klass_or_sym)
-        else
-          camelize_str(klass_or_sym)
-        end
-      end
-
-      def singular_class_present?(klass_or_sym)
-        parser_str = singularize_and_camelize_str(klass_or_sym)
-        concat_str(parser_str).safe_constantize.present?
-      end
-
-      def singularize_and_camelize_str(klass_or_sym)
-        klass_or_sym.to_s.singularize.camelize
-      end
-
-      def camelize_str(klass_or_sym)
-        klass_or_sym.to_s.camelize
-      end
-
-      def concat_str(parser_str)
-        "Decanter::Parser::".concat(parser_str)
       end
 
       # expand to include preparsers

--- a/lib/decanter/parser/utils.rb
+++ b/lib/decanter/parser/utils.rb
@@ -1,0 +1,31 @@
+module Decanter
+  module Parser
+    module Utils
+      # extract string transformation strategies
+      def symbol_to_string(klass_or_sym)
+        if singular_class_present?(klass_or_sym)
+          singularize_and_camelize_str(klass_or_sym)
+        else
+          camelize_str(klass_or_sym)
+        end
+      end
+
+      def singular_class_present?(klass_or_sym)
+        parser_str = singularize_and_camelize_str(klass_or_sym)
+        concat_str(parser_str).safe_constantize.present?
+      end
+
+      def singularize_and_camelize_str(klass_or_sym)
+        klass_or_sym.to_s.singularize.camelize
+      end
+
+      def camelize_str(klass_or_sym)
+        klass_or_sym.to_s.camelize
+      end
+
+      def concat_str(parser_str)
+        'Decanter::Parser::'.concat(parser_str)
+      end
+    end
+  end
+end

--- a/lib/decanter/version.rb
+++ b/lib/decanter/version.rb
@@ -1,3 +1,3 @@
 module Decanter
-  VERSION = '1.0.1'.freeze
+  VERSION = '1.0.2'.freeze
 end

--- a/spec/decanter/parser/parser_spec.rb
+++ b/spec/decanter/parser/parser_spec.rb
@@ -21,6 +21,15 @@ describe Decanter::Parser do
         parser.pre :date, :float
       end
     )
+    Object.const_set('CheckInFieldDataParser',
+      Class.new(Decanter::Parser::ValueParser) do
+        def self.name
+          'BarParser'
+        end
+      end.tap do |parser|
+        parser.pre :date, :float
+      end
+    )
   end
 
   describe '#klass_or_sym_to_str' do
@@ -54,10 +63,25 @@ describe Decanter::Parser do
 
     context 'for a symbol' do
 
-      let(:klass_or_sym) { :hot_dogs }
+      let(:klass_or_sym) { :hot_dog }
 
-      it 'returns the singularized, camelized string + Parser' do
+      it 'returns the camelized string + Parser' do
         expect(subject).to eq 'HotDogParser'
+      end
+      # it 'returns the singularized, camelized string + Parser' do
+      #   expect(subject).to eq 'HotDogParser'
+      # end
+    end
+
+    context 'for a symbol with _data' do
+
+      let(:klass_or_sym) { :check_in_field_data }
+
+      it 'does not change _data to _datum' do
+        expect(subject).to eq 'CheckInFieldDataParser'
+        # expect { subject }
+        #   .to raise_error(NameError, "cannot find parser 
+        #     #{klass_or_sym.to_s.singularize.camelize.concat('Parser')}")
       end
     end
   end
@@ -118,11 +142,21 @@ describe Decanter::Parser do
 
     subject { Decanter::Parser.parsers_for(:bar) }
 
+    let(:_data) { Decanter::Parser.parsers_for(:check_in_field_data) }
+
     it 'returns a flattened array of parsers' do
       expect(subject).to eq [
         Decanter::Parser::DateParser,
         Decanter::Parser::FloatParser,
         BarParser
+      ]
+    end
+
+    it 'returns Data instead of Datum' do
+      expect(_data).to eq [
+        Decanter::Parser::DateParser,
+        Decanter::Parser::FloatParser,
+        CheckInFieldDataParser
       ]
     end
   end


### PR DESCRIPTION
Resolve #46 

When passing a symbol to `klass_or_sym_to_str`, decanter would convert to a string, singularize, then camelize before attemping to constantize. This would transform any names with `_data` into `_datum`, raising an `ArgumentError`: "cannot lookup parser for...".

When a class is passed, we don't attempt to singularize the name value.

To address fringe cases like `data => datum`, decanter will first try to find the singularized version of the class, then fallback to the non-singularized version. If neither are found, it will raise an `ArgumentError` as expected.