### PR TITLE
If Fields Requireds, Raise ArgumentError with Nil Args

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    decanter (1.0.2)
+    decanter (1.0.3)
       actionpack (>= 4.2.10)
       activesupport
 
@@ -40,15 +40,14 @@ GEM
     loofah (2.1.1)
       crass (~> 1.0.2)
       nokogiri (>= 1.5.9)
-    method_source (0.8.2)
+    method_source (0.9.0)
     mini_portile2 (2.3.0)
     minitest (5.10.3)
     nokogiri (1.8.1)
       mini_portile2 (~> 2.3.0)
-    pry (0.10.4)
+    pry (0.11.3)
       coderay (~> 1.1.0)
-      method_source (~> 0.8.1)
-      slop (~> 3.4)
+      method_source (~> 0.9.0)
     rack (1.6.8)
     rack-test (0.6.3)
       rack (>= 1.0)
@@ -88,7 +87,6 @@ GEM
       json (>= 1.8, < 3)
       simplecov-html (~> 0.10.0)
     simplecov-html (0.10.2)
-    slop (3.6.0)
     thor (0.20.0)
     thread_safe (0.3.6)
     tzinfo (1.2.4)
@@ -107,4 +105,4 @@ DEPENDENCIES
   simplecov (~> 0.15.1)
 
 BUNDLED WITH
-   1.16.0
+   1.15.2


### PR DESCRIPTION
Resolve #27 

Why:

By default, Decanter was returning an empty hash when passing `nil` arguments to `decant()`.
When input fields are marked as required, we want to raise an error that notifies developers they must pass arguments.

Changes: 
 - `handle_empty_args` guard which implements `any_inputs_required?`
 - `any_inputs_required?` iterates over all handlers, and `try` to find any `required` keys.




