### PR TITLE
UnhandledKeysError

### DIFF
--- a/README.md
+++ b/README.md
@@ -503,3 +503,14 @@ Decanter.configuration.strict = true
 
 Likewise, you can put the above code in a specific environment configuration.
 
+Decanter Exceptions
+---
+
+ - MissingRequiredInputValue
+
+  Raised when required inputs have been enabled, but provided arguments to `decant()` do not contain values for those required inputs.
+
+ - UnhandledKeysError
+
+  Raised when there are unhandled keys.
+

--- a/lib/decanter.rb
+++ b/lib/decanter.rb
@@ -60,5 +60,6 @@ require 'decanter/configuration'
 require 'decanter/core'
 require 'decanter/base'
 require 'decanter/extensions'
+require 'decanter/exceptions'
 require 'decanter/parser'
 require 'decanter/railtie' if defined?(::Rails)

--- a/lib/decanter/core.rb
+++ b/lib/decanter/core.rb
@@ -2,13 +2,13 @@ require 'pry'
 
 module Decanter
   module Core
-
+    
     def self.included(base)
       base.extend(ClassMethods)
     end
 
     module ClassMethods
-
+      
       def input(name, parsers=nil, **options)
 
         _name = [name].flatten
@@ -92,7 +92,7 @@ module Decanter
             p "#{self.name} ignoring unhandled keys: #{unhandled_keys.join(', ')}."
             {}
           when :with_exception            
-            raise ArgumentError.new("#{self.name} received unhandled keys: #{unhandled_keys.join(', ')}.")
+            raise(UnhandledKeysError, "#{self.name} received unhandled keys: #{unhandled_keys.join(', ')}.")
           else
             args.select { |key| unhandled_keys.include? key }
           end

--- a/lib/decanter/exceptions.rb
+++ b/lib/decanter/exceptions.rb
@@ -1,0 +1,6 @@
+module Decanter
+  module Core
+    class Error < StandardError; end
+    class UnhandledKeysError < Error; end
+  end
+end

--- a/lib/decanter/version.rb
+++ b/lib/decanter/version.rb
@@ -1,3 +1,3 @@
 module Decanter
-  VERSION = '1.0.3'.freeze
+  VERSION = '1.0.4'.freeze
 end

--- a/spec/decanter/decanter_core_spec.rb
+++ b/spec/decanter/decanter_core_spec.rb
@@ -309,14 +309,14 @@ describe Decanter::Core do
 
         context 'when there are no ignored keys' do
           it 'raises an error' do
-            expect { dummy.unhandled_keys(args) }.to raise_error(ArgumentError)
+            expect { dummy.unhandled_keys(args) }.to raise_error(Decanter::Core::UnhandledKeysError)
           end
         end
 
         context 'when the unhandled keys are ignored' do          
           it 'does not raise an error' do
             dummy.ignore :foo
-            expect { dummy.unhandled_keys(args) }.to_not raise_error(ArgumentError)
+            expect { dummy.unhandled_keys(args) }.to_not raise_error(Decanter::Core::UnhandledKeysError)
           end          
         end
       end


### PR DESCRIPTION
Resolve #57 

Why:

Provide a custom error `UnhandledKeysError` that allows developers to catch or respond to, when they fail to handle keys.

Changes:

 - Implement `Decanter::Core::UnhandledKeysError` in `exceptions.rb`
 - Raise UnhandledKeysError in `unhandled_keys` method