### PR TITLE
Raise When Nil Value for Required Fields

### DIFF
--- a/lib/decanter/core.rb
+++ b/lib/decanter/core.rb
@@ -69,17 +69,13 @@ module Decanter
       end
 
       def any_inputs_required?
-        handlers.any? do |handler|     
-          return false unless handler.last && handler.last[:options]
-          handler.last[:options][:required]
-        end
+        required_inputs.any?
       end
 
       def required_inputs
         handlers.map do |h|
           options = h.last[:options]
-          return nil unless options && options[:required]
-          h.first.first
+          h.first.first if options && options[:required]
         end  
       end
 

--- a/lib/decanter/exceptions.rb
+++ b/lib/decanter/exceptions.rb
@@ -2,5 +2,7 @@ module Decanter
   module Core
     class Error < StandardError; end
     class UnhandledKeysError < Error; end
+    class ParamsError < Error; end
+    class MissingRequiredInputValue < Error; end
   end
 end

--- a/lib/decanter/exceptions.rb
+++ b/lib/decanter/exceptions.rb
@@ -2,7 +2,6 @@ module Decanter
   module Core
     class Error < StandardError; end
     class UnhandledKeysError < Error; end
-    class ParamsError < Error; end
     class MissingRequiredInputValue < Error; end
   end
 end

--- a/lib/decanter/version.rb
+++ b/lib/decanter/version.rb
@@ -1,3 +1,3 @@
 module Decanter
-  VERSION = '1.0.4'.freeze
+  VERSION = '1.1.4'.freeze
 end

--- a/spec/decanter/decanter_core_spec.rb
+++ b/spec/decanter/decanter_core_spec.rb
@@ -519,15 +519,37 @@ describe Decanter::Core do
   end
 
   describe '#decant' do
-    let(:args) { { foo: 'bar', baz: 'foo'} }  
-    subject { dummy.decant(args) }
+    let(:args) { { foo: 'bar', baz: 'foo'} }
+    let(:subject) { dummy.decant(args) }
+    let(:is_required) { true }
+    
+    let(:input_hash) do
+      {
+        key: 'sky',
+        options: {
+          required: is_required
+        }
+      }      
+    end
+    let(:handler) { [[:title], input_hash] }    
+    let(:handlers) { [handler] }   
 
     before(:each) do
       allow(dummy).to receive(:unhandled_keys).and_return(args)
       allow(dummy).to receive(:handled_keys).and_return(args)
     end
+    
+    context 'with args' do  
+      context 'when inputs are required' do
+        it 'should raise an exception if no required values' do
+          allow(dummy).to receive(:handlers).and_return(handlers)
 
-    context 'with args' do      
+          expect{subject}.to raise_error(
+            Decanter::Core::MissingRequiredInputValue
+          )
+        end
+      end
+
       it 'passes the args to unhandled keys' do
         subject
         expect(dummy).to have_received(:unhandled_keys).with(args)
@@ -578,7 +600,9 @@ describe Decanter::Core do
     end
     let(:handler) { [[:title], input_hash] }    
     let(:handlers) { [handler] }    
-    before(:each) { allow(dummy).to receive(:handlers).and_return(handlers) }    
+    before(:each) { 
+      allow(dummy).to receive(:handlers).and_return(handlers)
+    }    
 
     context 'when required' do
       it 'should return true' do
@@ -590,6 +614,36 @@ describe Decanter::Core do
       let(:is_required) { false }
       it 'should return false' do
         expect(dummy.any_inputs_required?).to be false
+      end
+    end
+  end
+
+  describe 'required_input_values_present?' do
+    let(:is_required) { true }
+    let(:args) { { title: 'RubyConf' } }
+    let(:input_hash) do
+      {
+        key: 'foo',
+        options: {
+          required: is_required
+        }
+      }      
+    end
+    let(:handler) { [[:title], input_hash] }    
+    let(:handlers) { [handler] }    
+    before(:each) { allow(dummy).to receive(:handlers).and_return(handlers) } 
+
+    context 'when required args are present' do
+      it 'should return true' do
+        result = dummy.required_input_values_present?(args)
+        expect(result).to be true
+      end
+    end
+    context 'when required args are not present' do
+      let(:args) { {name: 'Bob'} }
+      it 'should return false' do
+        result = dummy.required_input_values_present?(args)
+        expect(result).to be false
       end
     end
   end


### PR DESCRIPTION
Resolve #54 

Why:

  When inputs are required, we want Decanter to ensure required input values are passed when calling `decant()`.

Changes:

  - `MissingRequiredInputValue` is raised unless all required input values are present in the arguments passed to `decant()`.