### PR TITLE
Missing Required Input Bug

### DIFF
--- a/lib/decanter/core.rb
+++ b/lib/decanter/core.rb
@@ -55,8 +55,7 @@ module Decanter
 
       def decant(args)
         return handle_empty_args if args.blank?
-        return empty_required_input_error unless 
-          required_input_values_present?(args)
+        return empty_required_input_error unless required_input_values_present?(args)
         args = args.to_unsafe_h.with_indifferent_access if args.class.name == 'ActionController::Parameters'
         {}.merge( unhandled_keys(args) )
           .merge( handled_keys(args) )
@@ -78,6 +77,7 @@ module Decanter
       end
 
       def required_input_values_present?(args={})
+        return true unless any_inputs_required?
         required_inputs.all? do |input|
           args.keys.include?(input)
         end

--- a/lib/decanter/version.rb
+++ b/lib/decanter/version.rb
@@ -1,3 +1,3 @@
 module Decanter
-  VERSION = '1.1.5'.freeze
+  VERSION = '1.1.6'.freeze
 end


### PR DESCRIPTION
Why:

We found a bug where by `required_input_values_present?` was always returning false, triggering the `empty_required_input_error`, i.e. MissingRequiredInputError.

This was most likely due to the fact that we jumped to check if required input values were present in the arguments hash, before first checking wether or not there were ANY required inputs.

This meant that `required_input_values_present?` was always iterating over `[nil]` with `all?` (from `required_inputs`), and returning false.

Now we check `any_inputs_required` before iterating over the array of "required" input values provided by `required_inputs`.