### PR TITLE
`required_input_keys_present?` raising false negative for arg key values

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    decanter (1.1.4)
+    decanter (1.1.6)
       actionpack (>= 4.2.10)
       activesupport
 
@@ -27,6 +27,7 @@ GEM
       thread_safe (~> 0.3, >= 0.3.4)
       tzinfo (~> 1.1)
     builder (3.2.3)
+    coderay (1.1.2)
     concurrent-ruby (1.0.5)
     crass (1.0.3)
     diff-lcs (1.3)
@@ -39,10 +40,14 @@ GEM
     loofah (2.1.1)
       crass (~> 1.0.2)
       nokogiri (>= 1.5.9)
+    method_source (0.9.0)
     mini_portile2 (2.3.0)
     minitest (5.10.3)
     nokogiri (1.8.1)
       mini_portile2 (~> 2.3.0)
+    pry (0.11.3)
+      coderay (~> 1.1.0)
+      method_source (~> 0.9.0)
     rack (1.6.8)
     rack-test (0.6.3)
       rack (>= 1.0)
@@ -94,9 +99,10 @@ DEPENDENCIES
   bundler (~> 1.9)
   decanter!
   dotenv
+  pry
   rake (~> 10.0)
   rspec-rails
   simplecov (~> 0.15.1)
 
 BUNDLED WITH
-   1.16.0
+   1.16.1

--- a/lib/decanter/core.rb
+++ b/lib/decanter/core.rb
@@ -55,7 +55,7 @@ module Decanter
 
       def decant(args)
         return handle_empty_args if args.blank?
-        return empty_required_input_error unless required_input_values_present?(args)
+        return empty_required_input_error unless required_input_keys_present?(args)
         args = args.to_unsafe_h.with_indifferent_access if args.class.name == 'ActionController::Parameters'
         {}.merge( unhandled_keys(args) )
           .merge( handled_keys(args) )
@@ -76,10 +76,11 @@ module Decanter
         end  
       end
 
-      def required_input_values_present?(args={})
+      def required_input_keys_present?(args={})
         return true unless any_inputs_required?
-        required_inputs.all? do |input|
-          args.keys.include?(input)
+        compact_inputs = required_inputs.compact
+        compact_inputs.all? do |input|
+          args.keys.map(&:to_sym).include?(input)
         end
       end
 

--- a/lib/decanter/version.rb
+++ b/lib/decanter/version.rb
@@ -1,3 +1,3 @@
 module Decanter
-  VERSION = '1.1.6'.freeze
+  VERSION = '1.1.7'.freeze
 end

--- a/spec/decanter/decanter_core_spec.rb
+++ b/spec/decanter/decanter_core_spec.rb
@@ -618,9 +618,9 @@ describe Decanter::Core do
     end
   end
 
-  describe 'required_input_values_present?' do
+  describe 'required_input_keys_present?' do
     let(:is_required) { true }
-    let(:args) { { title: 'RubyConf' } }
+    let(:args) { { "title": "RubyConf" } }
     let(:input_hash) do
       {
         key: 'foo',
@@ -635,14 +635,14 @@ describe Decanter::Core do
 
     context 'when required args are present' do
       it 'should return true' do
-        result = dummy.required_input_values_present?(args)
+        result = dummy.required_input_keys_present?(args)
         expect(result).to be true
       end
     end
     context 'when required args are not present' do
       let(:args) { {name: 'Bob'} }
       it 'should return false' do
-        result = dummy.required_input_values_present?(args)
+        result = dummy.required_input_keys_present?(args)
         expect(result).to be false
       end
     end


### PR DESCRIPTION
In the rails environment, hash params are being passed to decanter with string keys.

In decanter, our `required_inputs` array values are symbols.

When testing decanter outside of rails, ruby would evaluate the symbols from the required_inputs array to the key symbols in our ruby hash params.

Decanter tests would pass, but Rails would always throw the `MissingRequiredInputValue` even if our required_inputs were present and given values.

To resolve, we need to transform our hash param keys to symbols so `required_input_keys_present?(args={})` can consistently evaluate two symbols; as opposed to a symbol and a string.

Rails environment:
<img width="1051" alt="screen shot 2018-02-06 at 4 11 13 pm" src="https://user-images.githubusercontent.com/968057/35887691-b73ce810-0b5a-11e8-9abc-f675880e1aeb.png">

Fix:
<img width="554" alt="screen shot 2018-02-06 at 4 32 09 pm" src="https://user-images.githubusercontent.com/968057/35887856-4d2b53ac-0b5b-11e8-88aa-0157b357a604.png">
