### PR TITLE
Check Input Values for `nil`

### DIFF
--- a/lib/decanter/core.rb
+++ b/lib/decanter/core.rb
@@ -80,7 +80,7 @@ module Decanter
         return true unless any_inputs_required?
         compact_inputs = required_inputs.compact
         compact_inputs.all? do |input|
-          args.keys.map(&:to_sym).include?(input)
+          args.keys.map(&:to_sym).include?(input) && !args[input].nil?
         end
       end
 

--- a/lib/decanter/version.rb
+++ b/lib/decanter/version.rb
@@ -1,3 +1,3 @@
 module Decanter
-  VERSION = '1.1.7'.freeze
+  VERSION = '1.1.8'.freeze
 end

--- a/spec/decanter/decanter_core_spec.rb
+++ b/spec/decanter/decanter_core_spec.rb
@@ -640,7 +640,7 @@ describe Decanter::Core do
       end
     end
     context 'when required args are not present' do
-      let(:args) { {name: 'Bob'} }
+      let(:args) { { name: 'Bob' } }
       it 'should return false' do
         result = dummy.required_input_keys_present?(args)
         expect(result).to be false


### PR DESCRIPTION
Why:

In addition to checking if `required` keys are present, we must also check if the key values are nil.
If they are, raise `MissingRequiredInputValue`.