### PR TITLE
Resolve Security Issues

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,9 +1,10 @@
 PATH
   remote: .
   specs:
-    decanter (1.1.7)
+    decanter (1.1.9)
       actionpack (>= 4.2.10)
       activesupport
+      rails-html-sanitizer (>= 1.0.4)
 
 GEM
   remote: https://rubygems.org/
@@ -28,7 +29,7 @@ GEM
       tzinfo (~> 1.1)
     builder (3.2.3)
     concurrent-ruby (1.0.5)
-    crass (1.0.3)
+    crass (1.0.4)
     diff-lcs (1.3)
     docile (1.1.5)
     dotenv (2.2.1)
@@ -36,13 +37,13 @@ GEM
     i18n (0.9.3)
       concurrent-ruby (~> 1.0)
     json (2.1.0)
-    loofah (2.1.1)
+    loofah (2.2.2)
       crass (~> 1.0.2)
       nokogiri (>= 1.5.9)
     method_source (0.9.0)
     mini_portile2 (2.3.0)
     minitest (5.11.3)
-    nokogiri (1.8.2)
+    nokogiri (1.8.5)
       mini_portile2 (~> 2.3.0)
     rack (2.0.4)
     rack-test (0.8.2)
@@ -50,8 +51,8 @@ GEM
     rails-dom-testing (2.0.3)
       activesupport (>= 4.2.0)
       nokogiri (>= 1.6)
-    rails-html-sanitizer (1.0.3)
-      loofah (~> 2.0)
+    rails-html-sanitizer (1.0.4)
+      loofah (~> 2.2, >= 2.2.2)
     railties (5.1.4)
       actionpack (= 5.1.4)
       activesupport (= 5.1.4)

--- a/decanter.gemspec
+++ b/decanter.gemspec
@@ -27,13 +27,13 @@ Gem::Specification.new do |spec|
   spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
   spec.require_paths = ['lib']
 
-  spec.add_dependency 'rails-html-sanitizer', '>= 1.0.4'
-  spec.add_dependency 'activesupport'
   spec.add_dependency 'actionpack', '>= 4.2.10'
+  spec.add_dependency 'activesupport'
+  spec.add_dependency 'rails-html-sanitizer', '>= 1.0.4'
 
-  spec.add_development_dependency 'simplecov', '~> 0.15.1'
   spec.add_development_dependency 'bundler', '~> 1.9'
+  spec.add_development_dependency 'dotenv'
   spec.add_development_dependency 'rake', '~> 10.0'
   spec.add_development_dependency 'rspec-rails'
-  spec.add_development_dependency 'dotenv'
+  spec.add_development_dependency 'simplecov', '~> 0.15.1'
 end

--- a/decanter.gemspec
+++ b/decanter.gemspec
@@ -27,6 +27,7 @@ Gem::Specification.new do |spec|
   spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
   spec.require_paths = ['lib']
 
+  spec.add_dependency 'rails-html-sanitizer', '>= 1.0.4'
   spec.add_dependency 'activesupport'
   spec.add_dependency 'actionpack', '>= 4.2.10'
 

--- a/lib/decanter/version.rb
+++ b/lib/decanter/version.rb
@@ -1,3 +1,3 @@
 module Decanter
-  VERSION = '1.1.8'.freeze
+  VERSION = '1.1.9'.freeze
 end


### PR DESCRIPTION
Resolves https://github.com/LaunchPadLab/opex/issues/168

Addresses `rails-html-sanitizer` and `loofah` security vulnerabilities. 

`rails-html-santizer` is a dependency of `actionpack`, of which the last version `4` is `4.2.10` (which is currently installed). Added `rails-html-sanitizer` as a direct dependency at `>=1.0.4` to resolve issue.