### PR TITLE
Fix missing inputs bug

### DIFF
--- a/lib/decanter/core.rb
+++ b/lib/decanter/core.rb
@@ -136,7 +136,7 @@ module Decanter
           if is_empty_input
             empty_required_input_error(name) if handler[:options][:required]
             # Skip handling empty inputs
-            return acc
+            next acc
           end
 
           acc.merge handle(handler, values)

--- a/lib/decanter/version.rb
+++ b/lib/decanter/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module Decanter
-  VERSION = '2.1.0'.freeze
+  VERSION = '2.1.1'.freeze
 end

--- a/spec/decanter/decanter_core_spec.rb
+++ b/spec/decanter/decanter_core_spec.rb
@@ -391,7 +391,7 @@ describe Decanter::Core do
       let(:params) { { description: 'My Trip Description' } }
       it 'should omit missing values' do
         decanted_params = decanter.decant(params)
-        # :description wasn't sent, so it shouldn't be in the result
+        # :name wasn't sent, so it shouldn't be in the result
         expect(decanted_params).to eq(params)
       end
     end

--- a/spec/decanter/decanter_core_spec.rb
+++ b/spec/decanter/decanter_core_spec.rb
@@ -388,7 +388,7 @@ describe Decanter::Core do
           input :description, :string
         end
       }
-      let(:params) { { name: 'My Trip' } }
+      let(:params) { { description: 'My Trip Description' } }
       it 'should omit missing values' do
         decanted_params = decanter.decant(params)
         # :description wasn't sent, so it shouldn't be in the result


### PR DESCRIPTION
This is an urgent issue caused by #72.

In a nutshell, any empty inputs cause Decanter to eject out of the parsing and thus not return anything for later inputs.

For example,

```ruby
class TripDecanter < Decanter::Base
  input :name, :string
  input :description, :string
end
```

```ruby
TripDecanter.decant(description: 'My Description')
=> {}
```

@dpikt `return` from within a block actually returns out of the method you are in (rather than returning from the block). It is confusing and has tripped me up once or twice 🙄. `next` will return the value to the block to proceed to the next item in the iteration.