### PR TITLE
Do not remove keys when values are empty, only when keys are empty

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    decanter (2.1.1)
+    decanter (2.1.2)
       actionpack (>= 4.2.10)
       activesupport
       rails-html-sanitizer (>= 1.0.4)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    decanter (2.1.0)
+    decanter (2.1.1)
       actionpack (>= 4.2.10)
       activesupport
       rails-html-sanitizer (>= 1.0.4)
@@ -27,9 +27,13 @@ GEM
       i18n (>= 0.7, < 2)
       minitest (~> 5.1)
       tzinfo (~> 1.1)
+    binding_of_caller (0.8.0)
+      debug_inspector (>= 0.0.1)
     builder (3.2.3)
+    coderay (1.1.2)
     concurrent-ruby (1.0.5)
     crass (1.0.4)
+    debug_inspector (0.0.3)
     diff-lcs (1.3)
     docile (1.3.1)
     erubi (1.7.1)
@@ -44,6 +48,16 @@ GEM
     minitest (5.11.3)
     nokogiri (1.8.5)
       mini_portile2 (~> 2.3.0)
+    pry (0.12.2)
+      coderay (~> 1.1.0)
+      method_source (~> 0.9.0)
+    pry-nav (0.3.0)
+      pry (>= 0.9.10, < 0.13.0)
+    pry-stack_explorer (0.4.9.3)
+      binding_of_caller (>= 0.7)
+      pry (>= 0.9.11)
+    pry-theme (1.3.0)
+      coderay (~> 1.1)
     rack (2.0.5)
     rack-test (1.1.0)
       rack (>= 1.0, < 3)
@@ -92,9 +106,12 @@ PLATFORMS
 DEPENDENCIES
   bundler
   decanter!
+  pry-nav
+  pry-stack_explorer
+  pry-theme
   rake
   rspec-rails
   simplecov
 
 BUNDLED WITH
-   1.16.6
+   1.17.3

--- a/decanter.gemspec
+++ b/decanter.gemspec
@@ -36,4 +36,7 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency 'rake'
   spec.add_development_dependency 'rspec-rails'
   spec.add_development_dependency 'simplecov'
+  spec.add_development_dependency 'pry-nav'
+  spec.add_development_dependency 'pry-stack_explorer'
+  spec.add_development_dependency 'pry-theme'
 end

--- a/lib/decanter/version.rb
+++ b/lib/decanter/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module Decanter
-  VERSION = '2.1.1'.freeze
+  VERSION = '2.1.2'.freeze
 end

--- a/spec/decanter/decanter_core_spec.rb
+++ b/spec/decanter/decanter_core_spec.rb
@@ -2,6 +2,7 @@
 
 require 'spec_helper'
 require 'rails_helper'
+require 'pry'
 
 describe Decanter::Core do
   let(:dummy) { Class.new(Decanter::Base) }
@@ -395,6 +396,22 @@ describe Decanter::Core do
         expect(decanted_params).to eq(params)
       end
     end
+
+    context 'with present non-required args containing an empty value' do
+      let(:decanter) {
+        Class.new(Decanter::Base) do
+          input :name, :string
+          input :description, :string
+        end
+      }
+      let(:params) { { name: '', description: 'My Trip Description' } }
+      let(:desired_result) { { name: nil, description: 'My Trip Description' } }
+      it 'should omit missing values' do
+        decanted_params = decanter.decant(params)
+        # :name wasn't sent, so it shouldn't be in the result
+        expect(decanted_params).to eq(desired_result)
+      end
+    end    
 
     context 'without args' do
       let(:args) { nil }

--- a/spec/readme_spec.rb
+++ b/spec/readme_spec.rb
@@ -203,7 +203,7 @@ describe 'examples from the readme' do
     end
   end
 
-  describe 'Squashing inputs', current: true do
+  describe 'Squashing inputs' do
     SquashDateParser = Class.new(Decanter::Parser::ValueParser) do
       parser do |values, _options|
         day, month, year = values.map(&:to_i)

--- a/spec/readme_spec.rb
+++ b/spec/readme_spec.rb
@@ -203,7 +203,7 @@ describe 'examples from the readme' do
     end
   end
 
-  describe 'Squashing inputs' do
+  describe 'Squashing inputs', current: true do
     SquashDateParser = Class.new(Decanter::Parser::ValueParser) do
       parser do |values, _options|
         day, month, year = values.map(&:to_i)


### PR DESCRIPTION
- This issue was found by @inveterateliterate - thanks!
- Decanter should not remove key/value pairs simply because the value is empty. It should, however, not add a key back in when the key is missing
- Since SquashParser allows for the handling of multiple inbound keys, we need to evaluate if a key is missing based on the array of keys that should be present

Edit: resolves #77 