### PR TITLE
Add deprecation warning to decanter v2

### DIFF
--- a/decanter.gemspec
+++ b/decanter.gemspec
@@ -37,5 +37,5 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency 'rspec-rails'
   spec.add_development_dependency 'simplecov'
 
-  spec.post_install_message = "WARNING: Decanter 2.x is unstable and not recommended for production use. Please use 1.x instead."
+  spec.post_install_message = "WARNING: Decanter 2.x is unstable and not recommended for production use. Please use another major version of this gem."
 end

--- a/decanter.gemspec
+++ b/decanter.gemspec
@@ -36,4 +36,6 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency 'rake'
   spec.add_development_dependency 'rspec-rails'
   spec.add_development_dependency 'simplecov'
+
+  spec.post_install_message = "WARNING: Decanter 2.x is unstable and not recommended for production use. Please use 1.x instead."
 end

--- a/lib/decanter/version.rb
+++ b/lib/decanter/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module Decanter
-  VERSION = '2.1.1'.freeze
+  VERSION = '2.1.2'.freeze
 end


### PR DESCRIPTION
To help prevent further use, in favor of v1 or a future v3.