### PR TITLE
allow adding :default_value to decanter input options

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    decanter (3.1.0)
+    decanter (3.2.0)
       actionpack (>= 4.2.10)
       activesupport
       rails-html-sanitizer (>= 1.0.4)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-      decanter (3.2.0)
+    decanter (3.2.0)
       actionpack (>= 4.2.10)
       activesupport
       rails-html-sanitizer (>= 1.0.4)

--- a/README.md
+++ b/README.md
@@ -226,7 +226,7 @@ _Note: we recommend using [Active Record validations](https://guides.rubyonrails
 If you provide the option `:default_value` for an input in your decanter, the input key will be initialized with the given default value. Input keys not found in the incoming data parameters will be set to the provided default rather than ignoring the missing key.
 
 ```ruby
-class TripDecanter <  Decanter::Base
+class SomeDecanter <  Decanter::Base
   input :some_boolean, :boolean, default_value: true
 end
 ```

--- a/README.md
+++ b/README.md
@@ -220,6 +220,17 @@ end
 
 _Note: we recommend using [Active Record validations](https://guides.rubyonrails.org/active_record_validations.html) to check for presence of an attribute, rather than using the `required` option. This method is intended for use in non-RESTful routes or cases where Active Record validations are not available._
 
+
+### Default values
+
+If you provide the option `:default_value` for an input in your decanter, the input key will be initialized with the given default value. Input keys not found in the incoming data parameters will be set to the provided default rather than ignoring the missing key.
+
+```ruby
+class TripDecanter <  Decanter::Base
+  input :some_boolean, :boolean, default_value: true
+end
+```
+
 ### Global configuration
 
 You can generate a local copy of the default configuration with `rails generate decanter:install`. This will create an initializer where you can do global configuration:

--- a/README.md
+++ b/README.md
@@ -223,12 +223,20 @@ _Note: we recommend using [Active Record validations](https://guides.rubyonrails
 
 ### Default values
 
-If you provide the option `:default_value` for an input in your decanter, the input key will be initialized with the given default value. Input keys not found in the incoming data parameters will be set to the provided default rather than ignoring the missing key.
+If you provide the option `:default_value` for an input in your decanter, the input key will be initialized with the given default value. Input keys not found in the incoming data parameters will be set to the provided default rather than ignoring the missing key. Note: `nil` and empty keys will not be overridden.
 
 ```ruby
-class SomeDecanter <  Decanter::Base
-  input :some_boolean, :boolean, default_value: true
+class TripDecanter <  Decanter::Base
+  input :name, :string
+  input :destination, :string, default_value: 'Chicago'
 end
+
+```
+
+```
+TripDecanter.decant({ name: 'Vacation 2020' })
+=> { name: 'Vacation 2020', destination: 'Chicago' }
+
 ```
 
 ### Global configuration

--- a/lib/decanter/core.rb
+++ b/lib/decanter/core.rb
@@ -57,9 +57,9 @@ module Decanter
         return handle_empty_args if args.blank?
         return empty_required_input_error unless required_input_keys_present?(args)
         args = args.to_unsafe_h.with_indifferent_access if args.class.name == 'ActionController::Parameters'
-        {}.merge( unhandled_keys(args) )
+        {}.merge(default_values)
+          .merge( unhandled_keys(args) )
           .merge( handled_keys(args) )
-          .merge( default_values )
       end
 
       def default_values

--- a/lib/decanter/core.rb
+++ b/lib/decanter/core.rb
@@ -65,9 +65,11 @@ module Decanter
 
       def default_keys
         # return keys with provided default value when key is not defined within incoming args
-        default_value_inputs
+        default_result = default_value_inputs
           .map { |input| [input[:key], input[:options][DEFAULT_VALUE_KEY]] }
           .to_h
+
+        handled_keys(default_result)
       end
 
       def default_value_inputs

--- a/lib/decanter/core.rb
+++ b/lib/decanter/core.rb
@@ -69,6 +69,7 @@ module Decanter
           .map { |input| [input[:key], input[:options][DEFAULT_VALUE_KEY]] }
           .to_h
 
+        # parse default values
         handled_keys(default_result)
       end
 

--- a/lib/decanter/core.rb
+++ b/lib/decanter/core.rb
@@ -1,5 +1,6 @@
 module Decanter
   module Core
+    DEFAULT_VALUE_KEY = :default_value
 
     def self.included(base)
       base.extend(ClassMethods)
@@ -57,20 +58,20 @@ module Decanter
         return handle_empty_args if args.blank?
         return empty_required_input_error unless required_input_keys_present?(args)
         args = args.to_unsafe_h.with_indifferent_access if args.class.name == 'ActionController::Parameters'
-        {}.merge(default_values)
+        {}.merge( default_keys )
           .merge( unhandled_keys(args) )
           .merge( handled_keys(args) )
       end
 
-      def default_values
+      def default_keys
         # return keys with provided default value when key is not defined within incoming args
         default_value_inputs
-          .map { |input| [input[:key], input[:options][:default_value]] }
+          .map { |input| [input[:key], input[:options][DEFAULT_VALUE_KEY]] }
           .to_h
       end
 
       def default_value_inputs
-        handlers.values.select { |input| input[:options].key?(:default_value) }
+        handlers.values.select { |input| input[:options].key?(DEFAULT_VALUE_KEY) }
       end
 
       def handle_empty_args

--- a/lib/decanter/version.rb
+++ b/lib/decanter/version.rb
@@ -1,3 +1,3 @@
 module Decanter
-  VERSION = '3.1.0'.freeze
+  VERSION = '3.2.0'.freeze
 end

--- a/spec/decanter/decanter_core_spec.rb
+++ b/spec/decanter/decanter_core_spec.rb
@@ -629,7 +629,7 @@ describe Decanter::Core do
         params = { description: 'My Trip Description', name: '' }
         desired_result = params.merge(name: nil)
         decanted_params = decanter.decant(params)
-        # :name has a default value of 'foo', but it was sent as and should remain ''
+        # :name has a default value of 'foo', but it was sent as empty and should remain empty/nil
         expect(decanted_params).to eq(desired_result)
       end
     end

--- a/spec/decanter/decanter_core_spec.rb
+++ b/spec/decanter/decanter_core_spec.rb
@@ -600,35 +600,43 @@ describe Decanter::Core do
       let(:decanter) {
         Class.new(Decanter::Base) do
           input :name, :string, default_value: 'foo'
+          input :cost, :float, default_value: '99.99'
           input :description, :string
         end
       }
 
-      it 'should include the missing key and its default value' do
+      it 'should include missing keys and their parsed default values' do
         params = { description: 'My Trip Description' }
         decanted_params = decanter.decant(params)
+        desired_result = params.merge(name: 'foo', cost: 99.99)
         # :name wasn't sent, but it should have a default value of 'foo'
-        expect(decanted_params).to eq(params.merge(name: 'foo'))
+        # :cost wasn't sent, but it should have a parsed float default value of 99.99
+        expect(decanted_params).to eq(desired_result)
+        expect(decanted_params[:cost]).to be_kind_of(Float)
       end
 
-      it 'should not override an existing value' do
-        params = { description: 'My Trip Description', name: 'bar' }
+      it 'should not override a (parsed) existing value' do
+        params = { description: 'My Trip Description', name: 'bar', cost: '25.99' }
         decanted_params = decanter.decant(params)
+        desired_result = params.merge(cost: 25.99)
         # :name has a default value of 'foo', but it was sent as and should remain 'bar'
-        expect(decanted_params).to eq(params)
+        # :cost has default value of '99.99', but it was sent as '25.99'
+        # and should have a parsed float value of 25.99
+        expect(decanted_params).to eq(desired_result)
       end
 
       it 'should not override an existing nil value' do
         params = { description: 'My Trip Description', name: nil }
         decanted_params = decanter.decant(params)
+        desired_result = params.merge(cost: 99.99)
         # :name has a default value of 'foo', but it was sent as and should remain nil
-        expect(decanted_params).to eq(params)
+        expect(decanted_params).to eq(desired_result)
       end
 
       it 'should not override an existing blank value' do
-        params = { description: 'My Trip Description', name: '' }
-        desired_result = params.merge(name: nil)
+        params = { description: 'My Trip Description', name: '', cost: '99.99' }
         decanted_params = decanter.decant(params)
+        desired_result = params.merge(name: nil, cost: 99.99)
         # :name has a default value of 'foo', but it was sent as empty and should remain empty/nil
         expect(decanted_params).to eq(desired_result)
       end

--- a/spec/decanter/decanter_core_spec.rb
+++ b/spec/decanter/decanter_core_spec.rb
@@ -319,11 +319,11 @@ describe Decanter::Core do
           end
         end
 
-        context 'when the unhandled keys are ignored' do          
+        context 'when the unhandled keys are ignored' do
           it 'does not raise an error' do
             dummy.ignore :foo
             expect { dummy.unhandled_keys(args) }.to_not raise_error(Decanter::UnhandledKeysError)
-          end          
+          end
         end
       end
 
@@ -528,24 +528,24 @@ describe Decanter::Core do
     let(:args) { { foo: 'bar', baz: 'foo'} }
     let(:subject) { dummy.decant(args) }
     let(:is_required) { true }
-    
+
     let(:input_hash) do
       {
         key: 'sky',
         options: {
           required: is_required
         }
-      }      
+      }
     end
-    let(:handler) { [[:title], input_hash] }    
-    let(:handlers) { [handler] }   
+    let(:handler) { [[:title], input_hash] }
+    let(:handlers) { [handler] }
 
     before(:each) do
       allow(dummy).to receive(:unhandled_keys).and_return(args)
       allow(dummy).to receive(:handled_keys).and_return(args)
     end
-    
-    context 'with args' do  
+
+    context 'with args' do
       context 'when inputs are required' do
         let(:decanter) {
           Class.new(Decanter::Base) do
@@ -592,6 +592,21 @@ describe Decanter::Core do
       it 'should omit missing values' do
         decanted_params = decanter.decant(params)
         # :name wasn't sent, so it shouldn't be in the result
+        expect(decanted_params).to eq(params)
+      end
+    end
+
+    context 'with missing args with a :default_value in the decanter' do
+      let(:decanter) {
+        Class.new(Decanter::Base) do
+          input :name, :string, default_value: 'foo'
+          input :description, :string
+        end
+      }
+      let(:params) { { description: 'My Trip Description', name: 'foo' } }
+      it 'should include the missing args key default value' do
+        decanted_params = decanter.decant(params)
+        # :name wasn't sent, but it should have a default value of 'foo'
         expect(decanted_params).to eq(params)
       end
     end
@@ -643,13 +658,13 @@ describe Decanter::Core do
         options: {
           required: is_required
         }
-      }      
+      }
     end
-    let(:handler) { [[:title], input_hash] }    
-    let(:handlers) { [handler] }    
-    before(:each) { 
+    let(:handler) { [[:title], input_hash] }
+    let(:handlers) { [handler] }
+    before(:each) {
       allow(dummy).to receive(:handlers).and_return(handlers)
-    }    
+    }
 
     context 'when required' do
       it 'should return true' do
@@ -674,11 +689,11 @@ describe Decanter::Core do
         options: {
           required: is_required
         }
-      }      
+      }
     end
-    let(:handler) { [[:title], input_hash] }    
-    let(:handlers) { [handler] }    
-    before(:each) { allow(dummy).to receive(:handlers).and_return(handlers) } 
+    let(:handler) { [[:title], input_hash] }
+    let(:handlers) { [handler] }
+    before(:each) { allow(dummy).to receive(:handlers).and_return(handlers) }
 
     context 'when required args are present' do
       it 'should return true' do

--- a/spec/decanter/decanter_core_spec.rb
+++ b/spec/decanter/decanter_core_spec.rb
@@ -596,7 +596,7 @@ describe Decanter::Core do
       end
     end
 
-    context 'with missing args with a :default_value in the decanter' do
+    context 'with missing args keys with a :default_value in the decanter' do
       let(:decanter) {
         Class.new(Decanter::Base) do
           input :name, :string, default_value: 'foo'

--- a/spec/decanter/decanter_core_spec.rb
+++ b/spec/decanter/decanter_core_spec.rb
@@ -596,18 +596,41 @@ describe Decanter::Core do
       end
     end
 
-    context 'with missing args keys with a :default_value in the decanter' do
+    context 'with key having a :default_value in the decanter' do
       let(:decanter) {
         Class.new(Decanter::Base) do
           input :name, :string, default_value: 'foo'
           input :description, :string
         end
       }
-      let(:params) { { description: 'My Trip Description', name: 'foo' } }
-      it 'should include the missing args key default value' do
+
+      it 'should include the missing key and its default value' do
+        params = { description: 'My Trip Description' }
         decanted_params = decanter.decant(params)
         # :name wasn't sent, but it should have a default value of 'foo'
+        expect(decanted_params).to eq(params.merge(name: 'foo'))
+      end
+
+      it 'should not override an existing value' do
+        params = { description: 'My Trip Description', name: 'bar' }
+        decanted_params = decanter.decant(params)
+        # :name has a default value of 'foo', but it was sent as and should remain 'bar'
         expect(decanted_params).to eq(params)
+      end
+
+      it 'should not override an existing nil value' do
+        params = { description: 'My Trip Description', name: nil }
+        decanted_params = decanter.decant(params)
+        # :name has a default value of 'foo', but it was sent as and should remain nil
+        expect(decanted_params).to eq(params)
+      end
+
+      it 'should not override an existing blank value' do
+        params = { description: 'My Trip Description', name: '' }
+        desired_result = params.merge(name: nil)
+        decanted_params = decanter.decant(params)
+        # :name has a default value of 'foo', but it was sent as and should remain ''
+        expect(decanted_params).to eq(desired_result)
       end
     end
 


### PR DESCRIPTION
## Items Addressed
<!-- Include description and link to resolved issue(s) here. -->
Issue #104 optional default value for when incoming args are missing decanter input keys

## Author Checklist
- [x] Add unit test(s)
- [x] Update documentation (if necessary)
- [x] Update version in `version.rb` following [versioning guidelines](https://github.com/LaunchPadLab/opex/blob/master/gists/gem-guidelines.md#pull-requests-and-deployments)

