### PR TITLE
Do not pin activesupport to a specific version

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,9 +1,9 @@
 PATH
   remote: .
   specs:
-    decanter (3.4.0)
+    decanter (3.4.1)
       actionpack (>= 4.2.10)
-      activesupport (~> 5.2)
+      activesupport
       rails-html-sanitizer (>= 1.0.4)
 
 GEM

--- a/decanter.gemspec
+++ b/decanter.gemspec
@@ -28,7 +28,7 @@ Gem::Specification.new do |spec|
   spec.require_paths = ['lib']
 
   spec.add_dependency 'actionpack', '>= 4.2.10'
-  spec.add_dependency 'activesupport', '~> 5.2'
+  spec.add_dependency 'activesupport'
   spec.add_dependency 'rails-html-sanitizer', '>= 1.0.4'
 
   spec.add_development_dependency 'bundler', '~> 1.9'

--- a/lib/decanter/version.rb
+++ b/lib/decanter/version.rb
@@ -1,3 +1,3 @@
 module Decanter
-  VERSION = '3.4.0'.freeze
+  VERSION = '3.4.1'.freeze
 end


### PR DESCRIPTION
## Items Addressed
- Resolves issues with `3.4.0` and older and newer versions of Rails raised in #112 

## Author Checklist
- [x] Update version in `version.rb` following [versioning guidelines](https://github.com/LaunchPadLab/opex-public/blob/master/gists/gem-guidelines.md#pull-requests-and-deployments)

