### PR TITLE
Strict ignore unhandled keys

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    decanter (3.4.2)
+    decanter (3.4.3)
       actionpack (>= 4.2.10)
       activesupport
       rails-html-sanitizer (>= 1.0.4)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    decanter (3.4.3)
+    decanter (3.5.0)
       actionpack (>= 4.2.10)
       activesupport
       rails-html-sanitizer (>= 1.0.4)

--- a/README.md
+++ b/README.md
@@ -144,7 +144,11 @@ input :start_date, :date, parse_format: '%Y-%m-%d'
 
 ### Exceptions
 
-By default, `Decanter#decant` will raise an exception when unexpected parameters are passed. To override this behavior, you can disable strict mode:
+By default, `Decanter#decant` will raise an exception when unexpected parameters are passed. To override this behavior, you can change the strict mode option to one of:
+
+- `:ignore`: unhandled keys will be ignored from the decanted result
+- `true`: unhandled keys will raise an unexpected parameters exception
+- `false`: all parameter key-value pairs will be included in the result
 
 ```ruby
 class TripDecanter <  Decanter::Base

--- a/README.md
+++ b/README.md
@@ -146,9 +146,9 @@ input :start_date, :date, parse_format: '%Y-%m-%d'
 
 By default, `Decanter#decant` will raise an exception when unexpected parameters are passed. To override this behavior, you can change the strict mode option to one of:
 
-- `:ignore`: unhandled keys will be excluded from the decanted result
+- `true` (default): unhandled keys will raise an unexpected parameters exception
 - `false`: all parameter key-value pairs will be included in the result
-- `true`: unhandled keys will raise an unexpected parameters exception
+- `:ignore`: unhandled keys will be excluded from the decanted result
 
 ```ruby
 class TripDecanter <  Decanter::Base

--- a/README.md
+++ b/README.md
@@ -146,7 +146,7 @@ input :start_date, :date, parse_format: '%Y-%m-%d'
 
 By default, `Decanter#decant` will raise an exception when unexpected parameters are passed. To override this behavior, you can change the strict mode option to one of:
 
-- `:ignore`: unhandled keys will be ignored from the decanted result
+- `:ignore`: unhandled keys will be excluded from the decanted result
 - `true`: unhandled keys will raise an unexpected parameters exception
 - `false`: all parameter key-value pairs will be included in the result
 

--- a/README.md
+++ b/README.md
@@ -147,8 +147,8 @@ input :start_date, :date, parse_format: '%Y-%m-%d'
 By default, `Decanter#decant` will raise an exception when unexpected parameters are passed. To override this behavior, you can change the strict mode option to one of:
 
 - `:ignore`: unhandled keys will be excluded from the decanted result
-- `true`: unhandled keys will raise an unexpected parameters exception
 - `false`: all parameter key-value pairs will be included in the result
+- `true`: unhandled keys will raise an unexpected parameters exception
 
 ```ruby
 class TripDecanter <  Decanter::Base

--- a/lib/decanter/core.rb
+++ b/lib/decanter/core.rb
@@ -58,25 +58,13 @@ module Decanter
         return handle_empty_args if args.blank?
         return empty_required_input_error unless required_input_keys_present?(args)
 
-        # Convert all params passed to a decanter to a hash with indifferent access to mitigate accessor ambiguity
-        # accessible_args = to_indifferent_hash(args)
-        # x = {}.merge( default_keys ).with_indifferent_access
-        # y = x.merge( unhandled_keys(accessible_args) ).with_indifferent_access
-        # p '*** unhandled_keys merge ***'
-        # p y
-        # binding.pry
-        # z = y.merge(handled_keys(y.merge(accessible_args)))
-        # binding.pry
-        # z
-
+        #Convert all params passed to a decanter to a hash with indifferent access to mitigate accessor ambiguity
         accessible_args = to_indifferent_hash(args)
-        combined_args = {}
-          .merge( default_keys )
-          .with_indifferent_access
-          .merge( unhandled_keys(accessible_args) )
 
-        combined_args
-          .merge(handled_keys(combined_args.merge(accessible_args)))
+        {}
+          .merge( default_keys )
+          .merge( unhandled_keys(accessible_args) )
+          .merge( handled_keys(accessible_args) )
       end
 
       def default_keys
@@ -85,8 +73,8 @@ module Decanter
           .map { |input| [input[:key], input[:options][DEFAULT_VALUE_KEY]] }
           .to_h
 
-        # parse handled default values, include keys with defaults not included in handled keys
-        # if
+        # parse handled default values, including keys
+        # with defaults not already managed by handled_keys
         default_result.merge(handled_keys(default_result))
       end
 

--- a/lib/decanter/core.rb
+++ b/lib/decanter/core.rb
@@ -60,7 +60,6 @@ module Decanter
 
         # Convert all params passed to a decanter to a hash with indifferent access to mitigate accessor ambiguity
         accessible_args = to_indifferent_hash(args)
-
         {}
           .merge( default_keys )
           .merge( unhandled_keys(accessible_args) )

--- a/lib/decanter/core.rb
+++ b/lib/decanter/core.rb
@@ -58,7 +58,7 @@ module Decanter
         return handle_empty_args if args.blank?
         return empty_required_input_error unless required_input_keys_present?(args)
 
-        #Convert all params passed to a decanter to a hash with indifferent access to mitigate accessor ambiguity
+        # Convert all params passed to a decanter to a hash with indifferent access to mitigate accessor ambiguity
         accessible_args = to_indifferent_hash(args)
 
         {}

--- a/lib/decanter/core.rb
+++ b/lib/decanter/core.rb
@@ -50,7 +50,7 @@ module Decanter
       end
 
       def strict(mode)
-        raise(ArgumentError, "#{self.name}: Unknown strict value #{mode}") unless [true, false].include? mode
+        raise(ArgumentError, "#{self.name}: Unknown strict value #{mode}") unless [:ignore, true, false].include? mode
         @strict_mode = mode
       end
 
@@ -121,8 +121,16 @@ module Decanter
             .map { |handler| "#{handler[:name]}_attributes".to_sym }
 
         return {} unless unhandled_keys.any?
-        raise(UnhandledKeysError, "#{self.name} received unhandled keys: #{unhandled_keys.join(', ')}.") if strict_mode
-        args.select { |key| unhandled_keys.include? key.to_sym }
+
+        case strict_mode
+        when :ignore
+          p "#{self.name} ignoring unhandled keys: #{unhandled_keys.join(', ')}."
+          {}
+        when true
+          raise(UnhandledKeysError, "#{self.name} received unhandled keys: #{unhandled_keys.join(', ')}.")
+        else
+          args.select { |key| unhandled_keys.include? key.to_sym }
+        end
       end
 
       def handled_keys(args)

--- a/lib/decanter/core.rb
+++ b/lib/decanter/core.rb
@@ -74,7 +74,8 @@ module Decanter
 
         # parse handled default values, including keys
         # with defaults not already managed by handled_keys
-        default_result.merge(handled_keys(default_result))
+        handled_keys(default_result)
+        # default_result.merge(handled_keys(default_result))
       end
 
       def default_value_inputs

--- a/lib/decanter/core.rb
+++ b/lib/decanter/core.rb
@@ -74,8 +74,7 @@ module Decanter
 
         # parse handled default values, including keys
         # with defaults not already managed by handled_keys
-        handled_keys(default_result)
-        # default_result.merge(handled_keys(default_result))
+        default_result.merge(handled_keys(default_result))
       end
 
       def default_value_inputs

--- a/lib/decanter/core.rb
+++ b/lib/decanter/core.rb
@@ -60,8 +60,7 @@ module Decanter
 
         # Convert all params passed to a decanter to a hash with indifferent access to mitigate accessor ambiguity
         accessible_args = to_indifferent_hash(args)
-        {}
-          .merge( default_keys )
+        {}.merge( default_keys )
           .merge( unhandled_keys(accessible_args) )
           .merge( handled_keys(accessible_args) )
       end

--- a/lib/decanter/version.rb
+++ b/lib/decanter/version.rb
@@ -1,3 +1,3 @@
 module Decanter
-  VERSION = '3.4.3'.freeze
+  VERSION = '3.5.0'.freeze
 end

--- a/lib/decanter/version.rb
+++ b/lib/decanter/version.rb
@@ -1,3 +1,3 @@
 module Decanter
-  VERSION = '3.4.2'.freeze
+  VERSION = '3.4.3'.freeze
 end

--- a/spec/decanter/decanter_core_spec.rb
+++ b/spec/decanter/decanter_core_spec.rb
@@ -564,7 +564,7 @@ describe Decanter::Core do
 
           let(:args) { { name: 'My Trip', description: 'My Trip Description', foo: 'bar' } }
 
-          it 'returns a hash with the declared key-value pairs, ignores unhandled key-vale pairs' do
+          it 'returns a hash with the declared key-value pairs, ignores unhandled key-value pairs' do
             decanter.strict :ignore
             decanted_params = decanter.decant(args)
 

--- a/spec/decanter/decanter_core_spec.rb
+++ b/spec/decanter/decanter_core_spec.rb
@@ -307,10 +307,9 @@ describe Decanter::Core do
 
     context 'when there are unhandled keys' do
 
-      before(:each) { allow(dummy).to receive(:handlers).and_return({}) }
-
       context 'and strict mode is true' do
 
+        before(:each) { allow(dummy).to receive(:handlers).and_return({}) }
         before(:each) { dummy.strict true }
 
         context 'when there are no ignored keys' do
@@ -327,10 +326,18 @@ describe Decanter::Core do
         end
       end
 
-      context 'and strict mode is false' do
+      context 'and strict mode is :ignore' do
 
+        it 'returns a hash without the unhandled keys and values' do
+          dummy.strict :ignore
+          expect(dummy.unhandled_keys(args)).to match({})
+        end
+      end
+
+      context 'and strict mode is false' do
         it 'returns a hash with the unhandled keys and values' do
           dummy.strict false
+          allow(dummy).to receive(:handlers).and_return({})
           expect(dummy.unhandled_keys(args)).to match(args)
         end
       end
@@ -546,6 +553,28 @@ describe Decanter::Core do
     end
 
     context 'with args' do
+      context 'when strict mode is set to :ignore' do
+        context 'and params include unhandled keys' do
+          let(:decanter) {
+            Class.new(Decanter::Base) do
+              input :name, :string
+              input :description, :string
+            end
+          }
+
+          let(:args) { { name: 'My Trip', description: 'My Trip Description', foo: 'bar' } }
+
+          it 'returns a hash with the declared key-value pairs, ignores unhandled key-vale pairs' do
+            decanter.strict :ignore
+            decanted_params = decanter.decant(args)
+
+            expect(decanted_params).not_to match(args)
+            expect(decanted_params.keys).not_to include([:foo])
+            expect(decanted_params.keys).to eq([:name, :description])
+          end
+        end
+      end
+
       context 'when inputs are required' do
         let(:decanter) {
           Class.new(Decanter::Base) do

--- a/spec/decanter/decanter_core_spec.rb
+++ b/spec/decanter/decanter_core_spec.rb
@@ -570,7 +570,6 @@ describe Decanter::Core do
 
             expect(decanted_params).not_to match(args)
             expect(decanted_params.keys).not_to include([:foo])
-            expect(decanted_params.keys).to eq([:name, :description])
           end
         end
       end


### PR DESCRIPTION
## Items Addressed
<!-- Include description and link to resolved issue(s) here. -->
Resolves #120 

- Adds `:ignore` as `strict` mode option, allowing unhandled keys to be excluded from the decanted result
- Update to the `default_value` functionality to include missing input keys with defaults at the beginning of the decant params, since I found a bug in cases where an input declaring both a `default_value` and alternate `key` for a missing parameter resulted in the default `{ key: :default value }` not getting merged into the final result

## Author Checklist
- [ ] Add unit test(s)
- [ ] Update documentation (if necessary)
- [ ] Update version in `version.rb` following [versioning guidelines](https://github.com/LaunchPadLab/opex-public/blob/master/gists/gem-guidelines.md#pull-requests-and-deployments)

