### PR TITLE
log_unhandled_keys config option

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    decanter (3.5.1)
+    decanter (3.6.0)
       actionpack (>= 4.2.10)
       activesupport
       rails-html-sanitizer (>= 1.0.4)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    decanter (3.7.0)
+    decanter (3.6.0)
       actionpack (>= 4.2.10)
       activesupport
       rails-html-sanitizer (>= 1.0.4)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    decanter (3.6.0)
+    decanter (3.7.0)
       actionpack (>= 4.2.10)
       activesupport
       rails-html-sanitizer (>= 1.0.4)

--- a/README.md
+++ b/README.md
@@ -280,11 +280,14 @@ TripDecanter.decant({ name: 'Vacation 2020' })
 
 You can generate a local copy of the default configuration with `rails generate decanter:install`. This will create an initializer where you can do global configuration:
 
+Setting strict mode to :ignore will log out any unhandled keys. To avoid excessive logging, the global configuration can be set to `log_unhandled_keys = false`
+
 ```ruby
 # ./config/initializers/decanter.rb
 
 Decanter.config do |config|
   config.strict = false
+  config.log_unhandled_keys = false
 end
 ```
 

--- a/lib/decanter/configuration.rb
+++ b/lib/decanter/configuration.rb
@@ -1,10 +1,11 @@
 module Decanter
   class Configuration
 
-    attr_accessor :strict
+    attr_accessor :strict, :log_unhandled_keys
 
     def initialize
       @strict = true
+      @log_unhandled_keys = true
     end
   end
 end

--- a/lib/decanter/core.rb
+++ b/lib/decanter/core.rb
@@ -54,6 +54,10 @@ module Decanter
         @strict_mode = mode
       end
 
+      def log_unhandled_keys(mode)
+        @log_unhandled_keys_mode = mode
+      end
+
       def decant(args)
         return handle_empty_args if args.blank?
         return empty_required_input_error unless required_input_keys_present?(args)
@@ -125,7 +129,7 @@ module Decanter
 
         case strict_mode
         when :ignore
-          p "#{self.name} ignoring unhandled keys: #{unhandled_keys.join(', ')}."
+          p "#{self.name} ignoring unhandled keys: #{unhandled_keys.join(', ')}." if log_unhandled_keys_mode
           {}
         when true
           raise(UnhandledKeysError, "#{self.name} received unhandled keys: #{unhandled_keys.join(', ')}.")
@@ -227,6 +231,10 @@ module Decanter
 
       def strict_mode
         @strict_mode.nil? ? Decanter.configuration.strict : @strict_mode
+      end
+
+      def log_unhandled_keys_mode
+        @log_unhandled_keys_mode.nil? ? Decanter.configuration.log_unhandled_keys : @log_unhandled_keys_mode
       end
 
       # Helpers

--- a/lib/decanter/core.rb
+++ b/lib/decanter/core.rb
@@ -55,6 +55,7 @@ module Decanter
       end
 
       def log_unhandled_keys(mode)
+        raise(ArgumentError, "#{self.name}: Unknown log_unhandled_keys value #{mode}") unless [true, false].include? mode
         @log_unhandled_keys_mode = mode
       end
 
@@ -234,7 +235,8 @@ module Decanter
       end
 
       def log_unhandled_keys_mode
-        @log_unhandled_keys_mode.nil? ? Decanter.configuration.log_unhandled_keys : @log_unhandled_keys_mode
+        return !!(Decanter.configuration.log_unhandled_keys) if @log_unhandled_keys_mode.nil?
+        !!@log_unhandled_keys_mode
       end
 
       # Helpers

--- a/lib/decanter/version.rb
+++ b/lib/decanter/version.rb
@@ -1,3 +1,3 @@
 module Decanter
-  VERSION = '3.5.1'.freeze
+  VERSION = '3.6.0'.freeze
 end

--- a/lib/decanter/version.rb
+++ b/lib/decanter/version.rb
@@ -1,3 +1,3 @@
 module Decanter
-  VERSION = '3.7.0'.freeze
+  VERSION = '3.6.0'.freeze
 end

--- a/lib/decanter/version.rb
+++ b/lib/decanter/version.rb
@@ -1,3 +1,3 @@
 module Decanter
-  VERSION = '3.6.0'.freeze
+  VERSION = '3.7.0'.freeze
 end

--- a/spec/decanter/decanter_core_spec.rb
+++ b/spec/decanter/decanter_core_spec.rb
@@ -173,9 +173,18 @@ describe Decanter::Core do
 
     let(:mode) { false }
 
-    it 'sets the log_unhandled_keys mode' do
-      dummy.log_unhandled_keys mode
-      expect(dummy.log_unhandled_keys mode).to eq mode
+    it 'sets the @log_unhandled_keys_mode' do
+      dummy.log_unhandled_keys(mode)
+      expect(dummy.log_unhandled_keys_mode).to eq mode
+    end
+
+    context 'for an unknown mode' do
+
+      let(:mode) { :foo }
+
+      it 'raises an error' do
+        expect { dummy.log_unhandled_keys(mode) }.to raise_error(ArgumentError)
+      end
     end
   end
 

--- a/spec/decanter/decanter_core_spec.rb
+++ b/spec/decanter/decanter_core_spec.rb
@@ -169,6 +169,16 @@ describe Decanter::Core do
     end
   end
 
+  describe '#log_unhandled_keys' do
+
+    let(:mode) { false }
+
+    it 'sets the log_unhandled_keys mode' do
+      dummy.log_unhandled_keys mode
+      expect(dummy.log_unhandled_keys mode).to eq mode
+    end
+  end
+
   describe '#parse' do
 
     context 'when a parser is not specified' do
@@ -331,6 +341,20 @@ describe Decanter::Core do
         it 'returns a hash without the unhandled keys and values' do
           dummy.strict :ignore
           expect(dummy.unhandled_keys(args)).to match({})
+        end
+
+        it 'logs the unhandled keys' do
+          dummy.strict :ignore
+          expect { dummy.unhandled_keys(args) }.to output(/ignoring unhandled keys: foo, baz/).to_stdout
+        end
+
+        context 'and log_unhandled_keys mode is false' do
+
+          it 'does not log the unhandled keys' do
+            dummy.strict :ignore
+            dummy.log_unhandled_keys false
+            expect { dummy.unhandled_keys(args) }.not_to output(/ignoring unhandled keys: foo, baz/).to_stdout
+          end
         end
       end
 


### PR DESCRIPTION
Add config option to control/prevent excessive logging (eg: in non-dev environments)

## Items Addressed
- Resolves #124 

## Author Checklist
- [x] Add unit test(s)
- [x] Update documentation (if necessary)
- [x] Update version in `version.rb` following [versioning guidelines](https://github.com/LaunchPadLab/opex-public/blob/master/gists/gem-guidelines.md#pull-requests-and-deployments)

