### PR TITLE
Negative numbers

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    decanter (3.6.1)
+    decanter (3.7.0)
       actionpack (>= 4.2.10)
       activesupport
       rails-html-sanitizer (>= 1.0.4)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    decanter (3.7.0)
+    decanter (4.0.0)
       actionpack (>= 4.2.10)
       activesupport
       rails-html-sanitizer (>= 1.0.4)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    decanter (3.6.0)
+    decanter (3.6.1)
       actionpack (>= 4.2.10)
       activesupport
       rails-html-sanitizer (>= 1.0.4)

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 Decanter is a Ruby gem that makes it easy to transform incoming data before it hits the model. You can think of Decanter as the opposite of Active Model Serializers (AMS). While AMS transforms your outbound data into a format that your frontend consumes, Decanter transforms your incoming data into a format that your backend consumes.
 
 ```ruby
-gem 'decanter', '~> 3.0'
+gem 'decanter', '~> 4.0'
 ```
 
 ## Migration Guides

--- a/lib/decanter/parser/float_parser.rb
+++ b/lib/decanter/parser/float_parser.rb
@@ -1,7 +1,7 @@
 module Decanter
   module Parser
     class FloatParser < ValueParser
-      REGEX = /(\d|[.])/
+      REGEX = /(\d|[.]|[-])/
 
       allow Float, Integer
 

--- a/lib/decanter/parser/integer_parser.rb
+++ b/lib/decanter/parser/integer_parser.rb
@@ -1,7 +1,7 @@
 module Decanter
   module Parser
     class IntegerParser < ValueParser
-      REGEX = /(\d|[.])/
+      REGEX = /(\d|[.]|[-])/
 
       allow Integer
 

--- a/lib/decanter/version.rb
+++ b/lib/decanter/version.rb
@@ -1,3 +1,3 @@
 module Decanter
-  VERSION = '3.6.0'.freeze
+  VERSION = '3.6.1'.freeze
 end

--- a/lib/decanter/version.rb
+++ b/lib/decanter/version.rb
@@ -1,3 +1,3 @@
 module Decanter
-  VERSION = '3.7.0'.freeze
+  VERSION = '4.0.0'.freeze
 end

--- a/lib/decanter/version.rb
+++ b/lib/decanter/version.rb
@@ -1,3 +1,3 @@
 module Decanter
-  VERSION = '3.6.1'.freeze
+  VERSION = '3.7.0'.freeze
 end

--- a/migration-guides/v4.0.0.md
+++ b/migration-guides/v4.0.0.md
@@ -1,0 +1,7 @@
+# v4.0.0 Migration Guide
+
+_Note: this guide assumes you are upgrading from decanter v3 to v4._
+
+This version contains the following breaking changes:
+
+1. `FloatParser` and `IntegerParser` have been updated to address a bug where negative numbers were being parsed as positive. In the (unlikely) event that your project was relying on the previous behavior, you can include the legacy version(s) of the parsers as custom parsers in your project. Their source code is available on the `v3` branch.

--- a/migration-guides/v4.0.0.md
+++ b/migration-guides/v4.0.0.md
@@ -4,4 +4,32 @@ _Note: this guide assumes you are upgrading from decanter v3 to v4._
 
 This version contains the following breaking changes:
 
-1. `FloatParser` and `IntegerParser` have been updated to address a bug where negative numbers were being parsed as positive. In the (unlikely) event that your project was relying on the previous behavior, you can include the legacy version(s) of the parsers as custom parsers in your project. Their source code is available on the `v3` branch.
+1. `FloatParser` and `IntegerParser` have been updated to address a bug where negative numbers were being parsed as positive. In the (unlikely) event that your project was relying on the previous behavior, you can pin the gem version to `v3.6.0` or include the legacy version(s) of the parsers as custom parsers in your project.
+
+To add a custom parser, add the new parser class to your project:
+
+```
+# app/parsers/postive_float_parser.rb
+
+class PositiveFloatParser < Decanter::Parser::ValueParser
+  REGEX = /(\d|[.])/
+
+  allow Float, Integer
+
+  parser do |val, options|
+    raise Decanter::ParseError.new 'Expects a single value' if val.is_a? Array
+    next if (val.nil? || val === '')
+    val.scan(REGEX).join.try(:to_f)
+  end
+end
+```
+
+Then, use the appropriate key to look up the parser in your decanter:
+
+```
+# app/decanters/product_decanter.rb
+
+class ProductDecanter <  Decanter::Base
+  input :price, :positive_float #=> PositiveFloatParser
+end
+```

--- a/migration-guides/v4.0.0.md
+++ b/migration-guides/v4.0.0.md
@@ -8,7 +8,7 @@ This version contains the following breaking changes:
 
 To add a custom parser, add the new parser class to your project:
 
-```
+```rb
 # app/parsers/postive_float_parser.rb
 
 class PositiveFloatParser < Decanter::Parser::ValueParser
@@ -26,7 +26,7 @@ end
 
 Then, use the appropriate key to look up the parser in your decanter:
 
-```
+```rb
 # app/decanters/product_decanter.rb
 
 class ProductDecanter <  Decanter::Base

--- a/spec/decanter/parser/float_parser_spec.rb
+++ b/spec/decanter/parser/float_parser_spec.rb
@@ -8,8 +8,16 @@ describe 'FloatParser' do
 
   describe '#parse' do
     context 'with a string' do
-      it 'returns a float' do
-        expect(parser.parse(name, '1.00')).to match({name => 1.00})
+      context 'with a positive value' do
+        it 'returns a float' do
+          expect(parser.parse(name, '1.00')).to match({name => 1.00})
+        end
+      end
+
+      context 'with a negative value' do
+        it 'returns a float' do
+          expect(parser.parse(name, '-1.00')).to match({name => -1.00})
+        end
       end
     end
 

--- a/spec/decanter/parser/float_parser_spec.rb
+++ b/spec/decanter/parser/float_parser_spec.rb
@@ -9,13 +9,13 @@ describe 'FloatParser' do
   describe '#parse' do
     context 'with a string' do
       context 'with a positive value' do
-        it 'returns a float' do
+        it 'returns a positive float' do
           expect(parser.parse(name, '1.00')).to match({name => 1.00})
         end
       end
 
       context 'with a negative value' do
-        it 'returns a float' do
+        it 'returns a negative float' do
           expect(parser.parse(name, '-1.00')).to match({name => -1.00})
         end
       end

--- a/spec/decanter/parser/float_parser_spec.rb
+++ b/spec/decanter/parser/float_parser_spec.rb
@@ -10,26 +10,26 @@ describe 'FloatParser' do
     context 'with a string' do
       context 'with a positive value' do
         it 'returns a positive float' do
-          expect(parser.parse(name, '1.00')).to match({ foo: 1.00 })
+          expect(parser.parse(name, '1.00')).to eq({ foo: 1.00 })
         end
       end
 
       context 'with a negative value' do
         it 'returns a negative float' do
-          expect(parser.parse(name, '-1.00')).to match({ foo: -1.00 })
+          expect(parser.parse(name, '-1.00')).to eq({ foo: -1.00 })
         end
       end
     end
 
     context 'with empty string' do
       it 'returns nil' do
-        expect(parser.parse(name, '')).to match({ foo: nil })
+        expect(parser.parse(name, '')).to eq({ foo: nil })
       end
     end
 
     context 'with nil' do
       it 'returns nil' do
-        expect(parser.parse(name, nil)).to match({ foo: nil })
+        expect(parser.parse(name, nil)).to eq({ foo: nil })
       end
     end
 

--- a/spec/decanter/parser/float_parser_spec.rb
+++ b/spec/decanter/parser/float_parser_spec.rb
@@ -10,26 +10,26 @@ describe 'FloatParser' do
     context 'with a string' do
       context 'with a positive value' do
         it 'returns a positive float' do
-          expect(parser.parse(name, '1.00')).to match({name => 1.00})
+          expect(parser.parse(name, '1.00')).to match({ foo: 1.00 })
         end
       end
 
       context 'with a negative value' do
         it 'returns a negative float' do
-          expect(parser.parse(name, '-1.00')).to match({name => -1.00})
+          expect(parser.parse(name, '-1.00')).to match({ foo: -1.00 })
         end
       end
     end
 
     context 'with empty string' do
       it 'returns nil' do
-        expect(parser.parse(name, '')).to match({name => nil})
+        expect(parser.parse(name, '')).to match({ foo: nil })
       end
     end
 
     context 'with nil' do
       it 'returns nil' do
-        expect(parser.parse(name, nil)).to match({name => nil})
+        expect(parser.parse(name, nil)).to match({ foo: nil })
       end
     end
 

--- a/spec/decanter/parser/integer_parser_spec.rb
+++ b/spec/decanter/parser/integer_parser_spec.rb
@@ -10,26 +10,26 @@ describe 'IntegerParser' do
     context 'with a string' do
       context 'with a positive value' do
         it 'returns a positive integer' do
-          expect(parser.parse(name, '1')).to match({name => 1})
+          expect(parser.parse(name, '1')).to eq({ foo: 1 })
         end
       end
 
       context 'with a negative value' do
         it 'returns a negative integer' do
-          expect(parser.parse(name, '-1')).to match({name => -1})
+          expect(parser.parse(name, '-1')).to eq({ foo: -1 })
         end
       end
     end
 
     context 'with empty string' do
       it 'returns nil' do
-        expect(parser.parse(name, '')).to match({name => nil})
+        expect(parser.parse(name, '')).to eq({ foo: nil })
       end
     end
 
     context 'with nil' do
       it 'returns nil' do
-        expect(parser.parse(name, nil)).to match({name => nil})
+        expect(parser.parse(name, nil)).to eq({ foo: nil })
       end
     end
 

--- a/spec/decanter/parser/integer_parser_spec.rb
+++ b/spec/decanter/parser/integer_parser_spec.rb
@@ -9,13 +9,13 @@ describe 'IntegerParser' do
   describe '#parse' do
     context 'with a string' do
       context 'with a positive value' do
-        it 'returns an integer' do
+        it 'returns a positive integer' do
           expect(parser.parse(name, '1')).to match({name => 1})
         end
       end
 
       context 'with a negative value' do
-        it 'returns an integer' do
+        it 'returns a negative integer' do
           expect(parser.parse(name, '-1')).to match({name => -1})
         end
       end

--- a/spec/decanter/parser/integer_parser_spec.rb
+++ b/spec/decanter/parser/integer_parser_spec.rb
@@ -8,8 +8,16 @@ describe 'IntegerParser' do
 
   describe '#parse' do
     context 'with a string' do
-      it 'returns an integer' do
-        expect(parser.parse(name, '1')).to match({name => 1})
+      context 'with a positive value' do
+        it 'returns an integer' do
+          expect(parser.parse(name, '1')).to match({name => 1})
+        end
+      end
+
+      context 'with a negative value' do
+        it 'returns an integer' do
+          expect(parser.parse(name, '-1')).to match({name => -1})
+        end
       end
     end
 


### PR DESCRIPTION
## Items Addressed
Resolves #125, bug where regex for parsing string float and integer values was not correctly evaluating negative numbers

## Author Checklist
- [x] Add unit test(s)
- [x] Update documentation (if necessary)
- [x] Update version in `version.rb` following [versioning guidelines](https://github.com/LaunchPadLab/opex-public/blob/master/gists/gem-guidelines.md#pull-requests-and-deployments)

